### PR TITLE
Use block to trap INT instead of trap.

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -241,8 +241,12 @@ module Powder
     def log
       path_to_log_file = "#{ENV['HOME']}/Library/Logs/Pow/apps/#{current_dir_name}.log"
       if File.exist? path_to_log_file
-        trap('INT') { say "\nExiting log..." }
-        system "tail -f #{path_to_log_file}"
+        begin
+          system "tail -f #{path_to_log_file}"
+        rescue Interrupt
+          say "\nExiting log..."
+          exit 130
+        end
       else
         say "There is no Pow log file, have you set this application up yet?"
       end
@@ -250,8 +254,12 @@ module Powder
 
     desc "applog", "Tails in current app"
     def applog(env="development")
-      trap('INT') { say "\nExiting applog..." }
-      system "tail -f log/#{env}.log" if is_powable?
+      begin
+        system "tail -f log/#{env}.log" if is_powable?
+      rescue Interrupt
+        say "\nExiting log..."
+        exit 130
+      end
     end
 
     desc "uninstall", "Uninstalls pow"


### PR DESCRIPTION
I was actually running powder 0.2.x when I noticed ^C caused an Interrupt exception when using `powder log` and `powder app log`. When I went to fork and submit a pull request, I noticed that SIGINT handling had already been implemented, but figured I'd send this over anyway. I, of course, understand completely if you decide to ignore this PR as well.

Everything I know about signal handling, I learned from [Jessie Storimer](http://www.jstorimer.com). He is has been a tremendous asset as I write more and more Unix-friendly scripts! Hope you find this interesting/helpful! :) Really happy to have powder for managing my pow.

`Signal::trap` is global. Once it is called, the specified signal is always trapped, regardless of what code follows. Using a block ensures that the signal is only trapped at the point we need the behavior. This has very little impact in executables, because one wouldn't normally load or require this code elsewhere, but it affords us two opportunities:

1. To avoid having any "infectious" code around, should someone copy/paste it elsewhere (all of the sudden the app prints "\nExiting log..." any time SIGINT is received).
2. Allows us to provide an exit code that will play well with other shell scripts that might sniff for exit codes.

More info on exit codes: http://tldp.org/LDP/abs/html/exitcodes.html